### PR TITLE
Adjust Top margin when AppBar is hidden

### DIFF
--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -55,7 +55,7 @@ ReactDOM.render(
               apiUrl="http://localhost:8000/django/api"
               user={user}
               services={config.services}
-              showAppBar
+              showAppBar={true}
             />
           }
         />

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -55,7 +55,7 @@ ReactDOM.render(
               apiUrl="http://localhost:8000/django/api"
               user={user}
               services={config.services}
-              showAppBar={true}
+              showAppBar
             />
           }
         />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,7 +87,7 @@ export function UserInterface(props: Props): JSX.Element {
     <ThemeProvider theme={theme}>
       {appbar}
       <CssBaseline />
-      <div style={{ marginTop: props.showAppBar ? "108px" : "0px" }}>
+      <div style={{ marginTop: props.showAppBar ? "108px" : "20px" }}>
         <Routes>
           <Route path="//*">
             <Route path="/">


### PR DESCRIPTION
# Description

Adjust top margin when AppBar is hidden.

It's now 20px, not 0, so it looks better when used as a component