### PR TITLE
feat: Add callback for opening a project in curate

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,12 +31,8 @@ interface Props {
   services?: Readonly<typeof defaultServices>;
   user?: User; // Optional mock user
   showAppBar: boolean;
+  launchCurateCallback?: (projectUid: string) => void;
 }
-
-const defaultProps = {
-  services: defaultServices,
-  user: undefined as User,
-};
 
 const useStyles = makeStyles(() => ({
   appBar: {
@@ -96,7 +92,12 @@ export function UserInterface(props: Props): JSX.Element {
             <Route path="users" element={<UsersView services={services} />} />
             <Route
               path="projects"
-              element={<ProjectsView services={services} />}
+              element={
+                <ProjectsView
+                  services={services}
+                  launchCurateCallback={props.launchCurateCallback}
+                />
+              }
             />
           </Route>
         </Routes>
@@ -105,6 +106,10 @@ export function UserInterface(props: Props): JSX.Element {
   );
 }
 
-UserInterface.defaultProps = defaultProps;
+UserInterface.defaultProps = {
+  services: defaultServices,
+  user: undefined as User,
+  launchCurateCallback: undefined,
+};
 
 export { Services };

--- a/src/views/ProjectsView.tsx
+++ b/src/views/ProjectsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, ChangeEvent } from "react";
+import { useEffect, useState, ChangeEvent, ReactElement } from "react";
 import { ServiceFunctions } from "@/api";
 import {
   Paper,
@@ -20,10 +20,10 @@ import {
   TableBody,
   TableRow,
   TableCell,
+  Tooltip,
 } from "@material-ui/core";
 import Autocomplete from "@material-ui/lab/Autocomplete";
-import { Clear } from "@material-ui/icons";
-import AddIcon from "@material-ui/icons/Add";
+import { Clear, Launch, Add } from "@material-ui/icons";
 import { useAuth } from "@/hooks/use-auth";
 import { Project, Profile, Team } from "@/interfaces";
 import { InviteDialog } from "@/components/InviteDialog";
@@ -51,9 +51,10 @@ const useStyles = (props: Props) =>
 
 interface Props {
   services: ServiceFunctions;
+  launchCurateCallback?: (projectUid: string) => void | null;
 }
 
-export const ProjectsView = (props: Props): JSX.Element => {
+export const ProjectsView = (props: Props): ReactElement => {
   const auth = useAuth();
   const [newProjectName, setNewProjectName] = useState<string>(); // string entered in text field in New Project dialog
   const [projects, setProjects] = useState<Project[]>([]); // all projects
@@ -117,6 +118,20 @@ export const ProjectsView = (props: Props): JSX.Element => {
           handleSelectChange={handleSelectChange}
           inviteToProject={() => inviteToProject(uid, projectInvitee)}
         />
+        <Tooltip
+          key={`tooltip-${name}`}
+          title={`Open ${name} in CURATE`}
+          placement="bottom"
+        >
+          <Button
+            onClick={() => {
+              if (!props.launchCurateCallback) return;
+              props.launchCurateCallback(uid);
+            }}
+          >
+            <Launch />
+          </Button>
+        </Tooltip>
       </TableCell>
     </TableRow>
   );
@@ -164,7 +179,7 @@ export const ProjectsView = (props: Props): JSX.Element => {
                   alignItems: "center",
                 }}
               >
-                <AddIcon
+                <Add
                   fontSize="large"
                   style={{ marginRight: "10px", color: "grey" }}
                 />
@@ -181,12 +196,7 @@ export const ProjectsView = (props: Props): JSX.Element => {
             </Table>
           </TableContainer>
 
-          <Dialog
-            open={dialogOpen}
-            onClose={() => {
-              setDialogOpen(false);
-            }}
-          >
+          <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
             <Card>
               <Paper
                 elevation={0}
@@ -301,4 +311,8 @@ export const ProjectsView = (props: Props): JSX.Element => {
       </Card>
     </div>
   );
+};
+
+ProjectsView.defaultProps = {
+  launchCurateCallback: undefined,
 };


### PR DESCRIPTION
# Description
Adds a callback and a "Launch" button, to open any project listed in the "Projects" table in curate (part of https://github.com/gliff-ai/roadmap/issues/46).

# Dependency changes
No

# Testing
No

# Documentation
No

# Migrations (if applicable)

Have any database migrations been committed as part of this pull request?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
