### PR TITLE
feat: AUDIT button in Projects table

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,6 +45,7 @@ interface Props {
   user?: User; // Optional mock user
   showAppBar: boolean;
   launchCurateCallback?: (projectUid: string) => void;
+  launchAuditCallback?: (projectUid: string) => void;
 }
 
 const useStyles = makeStyles(() => ({
@@ -118,6 +119,7 @@ export function UserInterface(props: Props): JSX.Element {
                   <ProjectsView
                     services={services}
                     launchCurateCallback={props.launchCurateCallback}
+                    launchAuditCallback={props.launchAuditCallback}
                   />
                 }
               />

--- a/src/views/ProjectsView.tsx
+++ b/src/views/ProjectsView.tsx
@@ -61,6 +61,7 @@ const useStyles = (props: Props) =>
 interface Props {
   services: ServiceFunctions;
   launchCurateCallback?: (projectUid: string) => void | null;
+  launchAuditCallback?: (projectUid: string) => void | null;
 }
 
 export const ProjectsView = (props: Props): ReactElement => {
@@ -136,6 +137,20 @@ export const ProjectsView = (props: Props): ReactElement => {
             onClick={() => {
               if (!props.launchCurateCallback) return;
               props.launchCurateCallback(uid);
+            }}
+          >
+            <Launch />
+          </Button>
+        </HtmlTooltip>
+        <HtmlTooltip
+          key={`tooltipAudit-${name}`}
+          title={`Open ${name} in AUDIT`}
+          placement="bottom"
+        >
+          <Button
+            onClick={() => {
+              if (!props.launchAuditCallback) return;
+              props.launchAuditCallback(uid);
             }}
           >
             <Launch />

--- a/src/views/ProjectsView.tsx
+++ b/src/views/ProjectsView.tsx
@@ -128,34 +128,38 @@ export const ProjectsView = (props: Props): ReactElement => {
           handleSelectChange={handleSelectChange}
           inviteToProject={() => inviteToProject(uid, projectInvitee)}
         />
-        <HtmlTooltip
-          key={`tooltip-${name}`}
-          title={`Open ${name} in CURATE`}
-          placement="bottom"
-        >
-          <Button
-            onClick={() => {
-              if (!props.launchCurateCallback) return;
-              props.launchCurateCallback(uid);
-            }}
+        {props.launchCurateCallback && (
+          <HtmlTooltip
+            key={`tooltip-${name}`}
+            title={`Open ${name} in CURATE`}
+            placement="bottom"
           >
-            <Launch />
-          </Button>
-        </HtmlTooltip>
-        <HtmlTooltip
-          key={`tooltipAudit-${name}`}
-          title={`Open ${name} in AUDIT`}
-          placement="bottom"
-        >
-          <Button
-            onClick={() => {
-              if (!props.launchAuditCallback) return;
-              props.launchAuditCallback(uid);
-            }}
+            <Button
+              onClick={() => {
+                if (!props.launchCurateCallback) return;
+                props.launchCurateCallback(uid);
+              }}
+            >
+              <Launch />
+            </Button>
+          </HtmlTooltip>
+        )}
+        {props.launchAuditCallback && (
+          <HtmlTooltip
+            key={`tooltipAudit-${name}`}
+            title={`Open ${name} in AUDIT`}
+            placement="bottom"
           >
-            <Launch />
-          </Button>
-        </HtmlTooltip>
+            <Button
+              onClick={() => {
+                if (!props.launchAuditCallback) return;
+                props.launchAuditCallback(uid);
+              }}
+            >
+              <Launch />
+            </Button>
+          </HtmlTooltip>
+        )}
       </TableCell>
     </TableRow>
   );


### PR DESCRIPTION
## Description

Adds buttons in the Projects table to launch AUDIT, so long as the callback is passed from DOMINATE.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
