### PR TITLE
feat: hide TS from users list

### DIFF
--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -30,6 +30,12 @@ const config = {
             name: "Jane James",
             is_collaborator: true,
           },
+          {
+            email: "trustedservice@gliff.app",
+            name: "trusted service 1",
+            is_collaborator: false,
+            is_trusted_service: true,
+          },
         ],
         pending_invites: [
           {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,6 +17,7 @@ export interface Profile {
   email: string;
   name: string;
   is_collaborator: boolean;
+  is_trusted_service: boolean;
 }
 
 export interface Team {

--- a/src/views/TeamView.tsx
+++ b/src/views/TeamView.tsx
@@ -109,7 +109,12 @@ export const TeamView = (props: Props): JSX.Element => {
     if (auth?.user?.email) {
       void props.services
         .queryTeam(null, auth.user.authToken)
-        .then((t: Team) => setTeam(t));
+        .then((t: Team) => {
+          t.profiles = t.profiles.filter(
+            ({ is_trusted_service }) => !is_trusted_service
+          );
+          setTeam(t);
+        });
     }
   }, [auth, props.services]);
 


### PR DESCRIPTION
The API now returns TS users in the users list, this filters them out (and updates the typescript interface and example)
