### PR TITLE
build: fix history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react": "^17.0.20",
         "@types/react-dom": "^17.0.1",
         "eslint": "^7.25.0",
-        "history": "^5.0.1",
+        "history": "==5.0.1",
         "jest": "^27.0.4",
         "prettier": "==2.3.0",
         "react": "^17.0.0",
@@ -38,7 +38,7 @@
         "@material-ui/core": "^4.11.3",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.58",
-        "history": "^5.0.1",
+        "history": "==5.0.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.1",
         "react-router-dom": "==6.0.0-beta.4"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^17.0.20",
     "@types/react-dom": "^17.0.1",
     "eslint": "^7.25.0",
-    "history": "^5.0.1",
+    "history": "==5.0.1",
     "jest": "^27.0.4",
     "prettier": "==2.3.0",
     "react": "^17.0.0",
@@ -47,7 +47,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
-    "history": "^5.0.1",
+    "history": "==5.0.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.1",
     "react-router-dom": "==6.0.0-beta.4"


### PR DESCRIPTION
as it says on the tin - needed because of react-router-dom eslewhere