### PR TITLE
chore!: bump to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gliff-ai/manage",
-  "version": "0.3.11",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gliff-ai/manage",
-      "version": "0.3.11",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "axios": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gliff-ai/manage",
-  "version": "0.3.11",
+  "version": "1.0.0",
   "description": "gliff.ai MANAGE",
   "repository": "git://github.com/gliff-ai/manage.git",
   "main": "dist/index.es.js",


### PR DESCRIPTION
as it says on the tin - should force a breaking change bumping us to v1.0.0; this makes dep management in DOMINATE easier