### PR TITLE
fix: Can't perform a React state update on an unmounted component

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,2 +1,13 @@
 export const imgSrc = (src: string, type = "svg"): string =>
   new URL(`/src/assets/${src}.${type}`, import.meta.url).href;
+
+export function setStateIfMounted(
+  newState: any,
+  setStateFunc: (state: any) => void,
+  isMounted: boolean
+): void {
+  // update state only if component is mounted
+  if (isMounted) {
+    setStateFunc(newState);
+  }
+}


### PR DESCRIPTION
## Description
some of the functions that run inside `useEffect` are `async` and end with a `setSomething` that sets a state. If a `setSomething` function runs when the React component has already been dismounted, then we get the "state update on an unmounted component" error. the bug is fixed by updating the state only if the component is mounted.