### PR TITLE
fix: hide audit button on free tier in Projects view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@gliff-ai/eslint-config": "^0.1.3",
-        "@gliff-ai/jest-browserstack-automate": "^4.1.0",
+        "@gliff-ai/jest-browserstack-automate": "^4.1.1",
         "@gliff-ai/style": "^2.7.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@gliff-ai/jest-browserstack-automate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/jest-browserstack-automate/-/jest-browserstack-automate-4.1.0.tgz",
-      "integrity": "sha512-+Eb9kke48/QIfLuTX9emGI5OQ5sUTiDxrsoWXcyfdoAA7f+Adane9Ggn341/DZUS6GIhpGNq+PaqFIe5CvwIOQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/jest-browserstack-automate/-/jest-browserstack-automate-4.1.2.tgz",
+      "integrity": "sha512-MQldRvIugrzllL/K8SCEm+MiEmLa0eGmyB8amwjzAX7K7O6y0w6C8R1Qpnmj6E8oo5d5Yit14Z5u0Rf8QB8v2A==",
       "dev": true,
       "dependencies": {
         "@percy/cli": "^1.0.0-beta.70",
@@ -9279,9 +9279,9 @@
       }
     },
     "@gliff-ai/jest-browserstack-automate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/jest-browserstack-automate/-/jest-browserstack-automate-4.1.0.tgz",
-      "integrity": "sha512-+Eb9kke48/QIfLuTX9emGI5OQ5sUTiDxrsoWXcyfdoAA7f+Adane9Ggn341/DZUS6GIhpGNq+PaqFIe5CvwIOQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/jest-browserstack-automate/-/jest-browserstack-automate-4.1.2.tgz",
+      "integrity": "sha512-MQldRvIugrzllL/K8SCEm+MiEmLa0eGmyB8amwjzAX7K7O6y0w6C8R1Qpnmj6E8oo5d5Yit14Z5u0Rf8QB8v2A==",
       "dev": true,
       "requires": {
         "@percy/cli": "^1.0.0-beta.70",

--- a/src/views/ProjectsView.tsx
+++ b/src/views/ProjectsView.tsx
@@ -308,13 +308,13 @@ export const ProjectsView = (props: Props): ReactElement => {
                           for (const profile of dialogInvitees) {
                             inviteToProject(newProjectUid, profile.email).catch(
                               (err) => {
-                                console.log(err);
+                                console.error(err);
                               }
                             );
                           }
                         },
                         (err) => {
-                          console.log(err);
+                          console.error(err);
                         }
                       );
                       setDialogOpen(false);

--- a/src/views/ProjectsView.tsx
+++ b/src/views/ProjectsView.tsx
@@ -150,7 +150,7 @@ export const ProjectsView = (props: Props): ReactElement => {
           launchCallback={() => props.launchCurateCallback(uid)}
           tooltip={`Open ${name} in CURATE`}
         />
-        {auth.user.isOwner && (
+        {auth.user.isOwner && props.launchAuditCallback !== null && (
           <LaunchIcon
             launchCallback={() => props.launchAuditCallback(uid)}
             tooltip={`Open ${name} in AUDIT`}


### PR DESCRIPTION
## Description

https://sentry.io/organizations/gliff-ai/issues/2794412996/?project=5812330&referrer=slack was caused by MANAGE not checking that `launchAuditCallback` was passed before rendering the audit button in the Projects view, so it was rendering on free tier accounts but not working.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
