### PR TITLE
fix: Add a plugin to a project at creation

### DIFF
--- a/examples/samples.ts
+++ b/examples/samples.ts
@@ -77,7 +77,11 @@ export const config = {
           pendingUsernames: ["user3@gliff.app"],
         },
       }),
-    createPlugin: (data): Promise<string> => Promise.resolve("key key key"),
+    createPlugin: (data): Promise<{ key: string; email: string }> =>
+      Promise.resolve({
+        key: "key key key",
+        email: "1234@trustedservice.gliff.app",
+      }),
     getPlugins: (data): Promise<IPlugin[]> =>
       Promise.resolve([
         {

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -114,7 +114,7 @@ export const PluginsView = ({ services }: Props): ReactElement => {
 
   const updatePlugins = (prevPlugin: IPlugin, plugin: IPlugin) => {
     void services.updatePlugin({ ...plugin }).then((result) => {
-      if (result) {
+      if (result && isMounted.current) {
         setPlugins((prevPlugins) =>
           prevPlugins.map((p) => (prevPlugin === p ? plugin : p))
         );


### PR DESCRIPTION
## Description
Fix a bug where Python and AI plugins cannot be invited to join projects before they have been created. This required changing how `ProjectsAutocomplete` works.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
