### PR TITLE
feat!: Add notepad for inputting a project's description

### DIFF
--- a/examples/samples.ts
+++ b/examples/samples.ts
@@ -21,7 +21,7 @@ export const config = {
       Promise.resolve({
         owner: {
           email: "user1@gliff.app",
-          id: 1 
+          id: 1,
         },
         profiles: [
           {
@@ -68,7 +68,7 @@ export const config = {
         { name: "Project 1", uid: "1" },
         { name: "Project 2", uid: "2" },
       ]),
-    updateProjectName: (data): Promise<boolean> => Promise.resolve(true),
+    updateProjectDetails: (data): Promise<boolean> => Promise.resolve(true),
     getCollectionMembers: (data) =>
       Promise.resolve({ usernames: [], pendingUsernames: [] }),
     createProject: (data): Promise<string> => Promise.resolve("3"),

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,7 +17,7 @@ interface Services {
   inviteUser: APIRoute | ServiceFunction;
   inviteCollaborator: APIRoute | ServiceFunction;
   getProjects: APIRoute | ServiceFunction;
-  updateProjectName: APIRoute | ServiceFunction;
+  updateProjectDetails: APIRoute | ServiceFunction;
   getProject: APIRoute | ServiceFunction;
   getCollectionMembers: APIRoute | ServiceFunction;
   createProject: APIRoute | ServiceFunction;

--- a/src/components/Notepad.tsx
+++ b/src/components/Notepad.tsx
@@ -1,0 +1,43 @@
+import { ReactElement, ChangeEventHandler } from "react";
+import { Box, TextField } from "@mui/material";
+
+interface Props {
+  value: string;
+  onChange: ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  maxCharacters?: number; // max number of characters in the string
+  rows?: number;
+  maxRows?: number;
+  placeholder?: string;
+}
+
+export const Notepad = (props: Props): ReactElement => (
+  <Box
+    sx={{
+      "& .MuiOutlinedInput-root": { height: "unset" },
+    }}
+    component="form"
+    autoComplete="off"
+  >
+    <TextField
+      placeholder={props.placeholder}
+      type="string"
+      inputProps={{
+        maxLength: props.maxCharacters,
+      }}
+      multiline
+      rows={props.rows}
+      maxRows={props.maxRows}
+      margin="none" // remove any margin added by default
+      value={props.value}
+      onChange={props.onChange}
+      variant="outlined"
+    />
+  </Box>
+);
+
+Notepad.defaultProps = {
+  maxCharacters: 250,
+  rows: undefined,
+  maxRows: undefined,
+  placeholder: undefined,
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,4 +5,5 @@ export { ProgressBar } from "./ProgressBar";
 export { AddPluginDialog } from "@/components/plugins/AddPluginDialog";
 export { EditPluginDialog } from "@/components/plugins/EditPluginDialog";
 export { DeletePluginDialog } from "@/components/plugins/DeletePluginDialog";
+export { Notepad } from "@/components/Notepad";
 export * from "@/components/table";

--- a/src/components/projects/CreateProjectDialog.tsx
+++ b/src/components/projects/CreateProjectDialog.tsx
@@ -21,7 +21,8 @@ import {
   lightGrey,
   IconButton as GliffIconButton,
 } from "@gliff-ai/style";
-import { Profile, Project } from "@/interfaces";
+import { Profile, Project, ProjectDetails } from "@/interfaces";
+import { Notepad } from "@/components";
 
 const useStyles = makeStyles({
   paperHeader: {
@@ -69,9 +70,11 @@ const useStyles = makeStyles({
 interface Props {
   projects: Project[] | null;
   invitees: Profile[] | null;
-  createProject: (name: string) => Promise<string>;
+  createProject: (projectDetails: ProjectDetails) => Promise<string>;
   inviteToProject: (uid: string, email: string) => Promise<void>;
 }
+
+const INITIAL_PROJECT_DETAILS: ProjectDetails = { name: "", description: "" };
 
 export function CreateProjectDialog({
   projects,
@@ -80,10 +83,17 @@ export function CreateProjectDialog({
   inviteToProject,
 }: Props): ReactElement | null {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
-  const [newProjectName, setNewProjectName] = useState<string>("");
+  const [projectDetails, setProjectDetails] = useState<ProjectDetails>(
+    INITIAL_PROJECT_DETAILS
+  );
   const [dialogInvitees, setDialogInvitees] = useState<Profile[] | null>([]);
 
   const classes = useStyles();
+
+  const closeDialog = (): void => {
+    setDialogOpen(false);
+    setProjectDetails(INITIAL_PROJECT_DETAILS);
+  };
 
   if (!invitees || !projects) return null;
 
@@ -96,7 +106,7 @@ export function CreateProjectDialog({
         onClick={() => setDialogOpen(true)}
         tooltipPlacement="top"
       />
-      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+      <Dialog open={dialogOpen} onClose={closeDialog}>
         <Card>
           <Paper
             className={classes.paperHeader}
@@ -107,7 +117,7 @@ export function CreateProjectDialog({
             <Typography className={classes.projectsTopography}>
               Create Project
             </Typography>
-            <IconButton onClick={() => setDialogOpen(false)}>
+            <IconButton onClick={closeDialog}>
               <SVG src={icons.removeLabel} className={classes.closeIcon} />
             </IconButton>
           </Paper>
@@ -120,9 +130,24 @@ export function CreateProjectDialog({
               placeholder="Project Name"
               style={{ width: "100%" }}
               onChange={(event) => {
-                setNewProjectName(event.target.value);
+                setProjectDetails((details) => ({
+                  ...details,
+                  name: event.target.value,
+                }));
               }}
               variant="standard"
+            />
+            <br />
+            <Notepad
+              placeholder="Project Description (Optional)"
+              value={projectDetails.description}
+              onChange={(event) => {
+                setProjectDetails((details) => ({
+                  ...details,
+                  description: event.target.value,
+                }));
+              }}
+              rows={6}
             />
             {/* eslint-disable react/jsx-props-no-spreading */}
             <Autocomplete
@@ -197,11 +222,11 @@ export function CreateProjectDialog({
                 variant="contained"
                 color="primary"
                 disabled={
-                  newProjectName === "" ||
-                  projects.map((p) => p.name).includes(newProjectName)
+                  projectDetails.name === "" ||
+                  projects.map((p) => p.name).includes(projectDetails.name)
                 }
                 onClick={() => {
-                  createProject(newProjectName).then(
+                  createProject(projectDetails).then(
                     (newProjectUid) => {
                       const invites = new Set<string>();
                       // Always invite the team owner
@@ -223,7 +248,7 @@ export function CreateProjectDialog({
                       console.error(err);
                     }
                   );
-                  setDialogOpen(false);
+                  closeDialog();
                 }}
               >
                 OK

--- a/src/components/projects/EditProjectDialog.tsx
+++ b/src/components/projects/EditProjectDialog.tsx
@@ -28,7 +28,8 @@ import {
   icons,
   lightGrey,
 } from "@gliff-ai/style";
-import { Profile, ProjectUser } from "@/interfaces";
+import { Profile, ProjectDetails, ProjectUser } from "@/interfaces";
+import { Notepad } from "@/components";
 
 const useStyles = makeStyles({
   paperHeader: {
@@ -104,12 +105,12 @@ const useStyles = makeStyles({
 
 interface Props {
   projectUid: string;
-  projectName: string;
+  projectDetails: ProjectDetails;
   projectUsers: ProjectUser[];
   invitees: Profile[];
-  updateProjectName: (data: {
+  updateProjectDetails: (data: {
     projectUid: string;
-    projectName: string;
+    projectDetails: ProjectDetails;
   }) => Promise<unknown>;
   inviteToProject: (uid: string, email: string) => Promise<void>;
   removeFromProject: (uid: string, email: string) => Promise<void>;
@@ -121,7 +122,7 @@ export function EditProjectDialog({
   projectUid,
   inviteToProject,
   removeFromProject,
-  updateProjectName,
+  updateProjectDetails,
   triggerRefetch,
   projectUsers,
   ...otherProps
@@ -129,8 +130,8 @@ export function EditProjectDialog({
   const classes = useStyles();
   const [open, setOpen] = useState<boolean>(false);
   const [selectedInvitees, setSelectedInvitees] = useState<Profile[]>(null);
-  const [projectName, setProjectName] = useState<string>(
-    otherProps.projectName
+  const [projectDetails, setProjectDetails] = useState<ProjectDetails>(
+    otherProps.projectDetails
   );
 
   const alreadyInvited = useCallback(
@@ -184,8 +185,14 @@ export function EditProjectDialog({
   const updateProject = async () => {
     await changeCollectionMembers();
 
-    if (projectName !== otherProps.projectName) {
-      await updateProjectName({ projectUid, projectName });
+    const { name: newName, description: newDescription } = projectDetails;
+    const { name, description } = otherProps.projectDetails;
+
+    if (newName !== name || newDescription !== description) {
+      await updateProjectDetails({
+        projectUid,
+        projectDetails,
+      });
     }
 
     triggerRefetch(projectUid);
@@ -208,10 +215,25 @@ export function EditProjectDialog({
       <TextField
         placeholder="Project Name"
         variant="outlined"
-        value={projectName}
+        value={projectDetails.name}
         onChange={(event) => {
-          setProjectName(event.target.value);
+          setProjectDetails((details) => ({
+            ...details,
+            name: event.target.value,
+          }));
         }}
+      />
+      <br />
+      <Notepad
+        placeholder="Project Description (Optional)"
+        value={projectDetails.description}
+        onChange={(event) => {
+          setProjectDetails((details) => ({
+            ...details,
+            description: event.target.value,
+          }));
+        }}
+        rows={6}
       />
     </Paper>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,7 @@ const defaultServices = {
   inviteUser: "POST /user/invite",
   inviteCollaborator: "POST /user/invite/collaborator",
   getProjects: "GET /projects",
-  updateProjectName: "POST /project/uid",
+  updateProjectDetails: "POST /project/uid",
   getProject: "GET /project", // TODO: Support named params for GET? Body works tho...
   getCollectionMembers: "GET /team/collectionmembers",
   createProject: "POST /projects",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,7 +21,10 @@ export enum UserAccess {
 export type Project = {
   uid: string;
   name: string;
+  description?: string;
 };
+
+export type ProjectDetails = Omit<Project, "uid">;
 
 export type ProjectUsers = {
   [uid: string]: ProjectUser[];

--- a/src/views/ProjectsView.tsx
+++ b/src/views/ProjectsView.tsx
@@ -12,6 +12,7 @@ import {
   Progress,
   ProjectUsers,
   ProjectUser,
+  ProjectDetails,
 } from "@/interfaces";
 import {
   EditProjectDialog,
@@ -223,9 +224,11 @@ export const ProjectsView = ({
     console.log(`${email} removed from project ${projectUid}.`);
   };
 
-  const createProject = async (name: string): Promise<string> => {
+  const createProject = async (
+    projectDetails: ProjectDetails
+  ): Promise<string> => {
     const projectId = (await services.createProject({
-      name,
+      ...projectDetails,
     })) as string;
     const p = (await services.getProjects()) as Project[];
     setProjects(p);
@@ -283,7 +286,7 @@ export const ProjectsView = ({
                 : ["Name", "Annotation Progress"]
             }
           >
-            {projects.map(({ name, uid }) => (
+            {projects.map(({ name, uid, description = "" }) => (
               <TableRow key={uid}>
                 <TableCell>{name}</TableCell>
                 {isOwnerOrMember() && (
@@ -298,10 +301,10 @@ export const ProjectsView = ({
                     projectUsers[uid] !== undefined && (
                       <EditProjectDialog
                         projectUid={uid}
-                        projectName={name}
+                        projectDetails={{ name, description }}
                         projectUsers={projectUsers[uid]}
                         invitees={invitees}
-                        updateProjectName={services.updateProjectName}
+                        updateProjectDetails={services.updateProjectDetails}
                         inviteToProject={inviteToProject}
                         removeFromProject={removeFromProject}
                         triggerRefetch={triggerRefetch}


### PR DESCRIPTION
## Description
Add a notepad for inputting a project's description, which can be used to record any qualitative info (see gliff-ai/curate#348). A description can be added at project creation and edited from the edit-project dialog on the "projects" page.

relates to gliff-ai/curate#348

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
