### PR TITLE
fix: Plugin names longer than 50 result in a 500 

### DIFF
--- a/src/components/plugins/AddPluginDialog.tsx
+++ b/src/components/plugins/AddPluginDialog.tsx
@@ -235,11 +235,14 @@ export function AddPluginDialog({
     <>
       <TextField
         className={classes.marginTop}
-        variant="outlined"
         placeholder="Plug-in Name"
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
           setNewPlugin((p) => ({ ...p, name: e.target.value } as IPlugin));
         }}
+        inputProps={{
+          maxLength: 50, // NOTE: name for python or AI plugins cannot be over 50 characters, otherwise 500
+        }}
+        variant="outlined"
       />
       <Divider className={classes.divider} />
       <TextField

--- a/src/components/plugins/AddPluginDialog.tsx
+++ b/src/components/plugins/AddPluginDialog.tsx
@@ -252,8 +252,9 @@ export function AddPluginDialog({
         type="url"
         error={!validUrl}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
-          setValidUrl(isValidURL(e.target.value));
-          setNewPlugin((p) => ({ ...p, url: e.target.value } as IPlugin));
+          const url = e.target.value.replace(/\/$/, ""); // remove trailing slash
+          setValidUrl(isValidURL(url));
+          setNewPlugin((p) => ({ ...p, url } as IPlugin));
         }}
       />
       <Divider className={classes.divider} />

--- a/src/components/plugins/EditPluginDialog.tsx
+++ b/src/components/plugins/EditPluginDialog.tsx
@@ -138,12 +138,15 @@ export function EditPluginDialog({
     <>
       <TextField
         className={classes.marginTop}
-        variant="outlined"
         value={newPlugin.name}
         placeholder="Plug-in Name"
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
           setNewPlugin((p) => ({ ...p, name: e.target.value } as IPlugin));
         }}
+        inputProps={{
+          maxLength: 50, // NOTE: name for python or AI plugins cannot be over 50 characters, otherwise 500
+        }}
+        variant="outlined"
       />
 
       <Divider className={classes.divider} />


### PR DESCRIPTION
## Description
- set a max length for plugin names 
- removed triling slash from URL entered when registering a plugin, so the URL is correct, whether a trailing stash is entered or not during the plugin registration.

closes gliff-ai/manage#333

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
