### PR TITLE
feat!: Improve the assignment of plugins to projects

### DIFF
--- a/examples/samples.ts
+++ b/examples/samples.ts
@@ -1,9 +1,9 @@
 import {
   UserAccess,
-  IPlugin,
   PluginType,
   Product,
   Progress,
+  IPluginIn,
 } from "@/interfaces";
 import type { Services } from "../src";
 
@@ -107,7 +107,7 @@ export const config = {
         key: "key key key",
         email: "1234@trustedservice.gliff.app",
       }),
-    getPlugins: (data): Promise<IPlugin[]> =>
+    getPlugins: (data): Promise<IPluginIn[]> =>
       Promise.resolve([
         {
           username: "1234@trustedservice.gliff.app",
@@ -116,8 +116,8 @@ export const config = {
           url: "https://ts.gliff.app",
           products: Product.ALL,
           enabled: false,
-          collection_uids: ["1"],
-        } as IPlugin,
+          collection_uids: [{ uid: "1", is_invite_pending: "True" }],
+        } as IPluginIn,
         {
           type: PluginType.Javascript,
           name: "js-plugin",
@@ -125,7 +125,7 @@ export const config = {
           products: Product.CURATE,
           enabled: true,
           collection_uids: [],
-        } as IPlugin,
+        } as IPluginIn,
       ]),
     updatePlugin: (data): Promise<number> => Promise.resolve(1),
     deletePlugin: (data): Promise<number> => Promise.resolve(1),

--- a/examples/samples.ts
+++ b/examples/samples.ts
@@ -116,7 +116,7 @@ export const config = {
           url: "https://ts.gliff.app",
           products: Product.ALL,
           enabled: false,
-          collection_uids: [{ uid: "1", is_invite_pending: "True" }],
+          collection_uids: [{ uid: "1", is_invite_pending: true }],
         } as IPluginIn,
         {
           type: PluginType.Javascript,

--- a/src/components/plugins/AddPluginDialog.tsx
+++ b/src/components/plugins/AddPluginDialog.tsx
@@ -15,7 +15,7 @@ import {
   Box,
   Divider,
 } from "@gliff-ai/style";
-import { IPlugin, Product, PluginType, Project } from "@/interfaces";
+import { IPluginOut, Product, PluginType, Project } from "@/interfaces";
 import { ServiceFunctions } from "@/api";
 import { FormLabelControl } from "./FormLabelControl";
 import { ProductsRadioForm } from "./ProductsRadioForm";
@@ -76,7 +76,7 @@ export function AddPluginDialog({
   const [key, setKey] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [dialogPage, setDialogPage] = useState(DialogPage.pickPluginType);
-  const [newPlugin, setNewPlugin] = useState<IPlugin>(defaultPlugin);
+  const [newPlugin, setNewPlugin] = useState<IPluginOut>(defaultPlugin);
   const [validUrl, setValidUrl] = useState<boolean>(true);
 
   useEffect(() => {
@@ -101,7 +101,7 @@ export function AddPluginDialog({
 
   if (!projects) return null;
 
-  const addPluginToProjects = async (plugin: IPlugin, email: string) => {
+  const addPluginToProjects = async (plugin: IPluginOut, email: string) => {
     await Promise.allSettled(
       plugin.collection_uids.map(async (projectUid) => {
         try {
@@ -148,7 +148,7 @@ export function AddPluginDialog({
     <Box>
       <FormControl
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
-          setNewPlugin((p) => ({ ...p, type: e.target.value } as IPlugin));
+          setNewPlugin((p) => ({ ...p, type: e.target.value } as IPluginOut));
         }}
       >
         <h3>What type of plug-in do you want to register?</h3>
@@ -211,7 +211,7 @@ export function AddPluginDialog({
         sx={{ ...marginTop }}
         placeholder="Plug-in Name"
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
-          setNewPlugin((p) => ({ ...p, name: e.target.value } as IPlugin));
+          setNewPlugin((p) => ({ ...p, name: e.target.value } as IPluginOut));
         }}
         inputProps={{
           maxLength: 50, // NOTE: name for python or AI plugins cannot be over 50 characters, otherwise 500
@@ -228,7 +228,7 @@ export function AddPluginDialog({
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
           const url = e.target.value.replace(/\/$/, ""); // remove trailing slash
           setValidUrl(isValidURL(url));
-          setNewPlugin((p) => ({ ...p, url } as IPlugin));
+          setNewPlugin((p) => ({ ...p, url } as IPluginOut));
         }}
       />
       <Divider sx={{ ...divider }} />

--- a/src/components/plugins/DeletePluginDialog.tsx
+++ b/src/components/plugins/DeletePluginDialog.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
   AdvancedDialog,
 } from "@gliff-ai/style";
-import { IPlugin } from "@/interfaces";
+import { IPluginOut } from "@/interfaces";
 import { ServiceFunctions } from "@/api";
 
 const purpleText = {
@@ -45,8 +45,8 @@ const purpleButtonStyle = {
 };
 
 interface Props {
-  plugin: IPlugin;
-  setPlugins: Dispatch<SetStateAction<IPlugin[]>>;
+  plugin: IPluginOut;
+  setPlugins: Dispatch<SetStateAction<IPluginOut[]>>;
   services: ServiceFunctions;
 }
 

--- a/src/components/plugins/EditPluginDialog.tsx
+++ b/src/components/plugins/EditPluginDialog.tsx
@@ -11,7 +11,7 @@ import {
   Button,
   Typography,
 } from "@gliff-ai/style";
-import { IPlugin, PluginType, Project } from "@/interfaces";
+import { IPluginOut, PluginType, Project } from "@/interfaces";
 import { ProjectsAutocomplete } from "./ProjectsAutocomplete";
 import { ProductsRadioForm } from "./ProductsRadioForm";
 import { ServiceFunctions } from "../../api";
@@ -39,21 +39,23 @@ const greenButtonStyle = {
 };
 
 interface Props {
-  plugin: IPlugin;
+  pendingProjectInvites: string[];
+  plugin: IPluginOut;
   allProjects: Project[] | null;
-  updatePlugins: (prevPlugin: IPlugin, plugin: IPlugin) => void;
+  updatePlugins: (prevPlugin: IPluginOut, plugin: IPluginOut) => void;
   services: ServiceFunctions;
   setError: (error: string) => void;
 }
 
 export function EditPluginDialog({
+  pendingProjectInvites,
   plugin,
   allProjects,
   updatePlugins,
   services,
   setError,
 }: Props): ReactElement {
-  const [newPlugin, setNewPlugin] = useState<IPlugin>(plugin);
+  const [newPlugin, setNewPlugin] = useState<IPluginOut>(plugin);
   const [closeDialog, setCloseDialog] = useState<boolean>(false);
 
   const resetDefaults = (): void => {
@@ -123,7 +125,7 @@ export function EditPluginDialog({
         value={newPlugin.name}
         placeholder="Plug-in Name"
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
-          setNewPlugin((p) => ({ ...p, name: e.target.value } as IPlugin));
+          setNewPlugin((p) => ({ ...p, name: e.target.value } as IPluginOut));
         }}
         inputProps={{
           maxLength: 50, // NOTE: name for python or AI plugins cannot be over 50 characters, otherwise 500
@@ -147,6 +149,7 @@ export function EditPluginDialog({
       <ProductsRadioForm newPlugin={newPlugin} setNewPlugin={setNewPlugin} />
       <Divider sx={{ ...divider }} />
       <ProjectsAutocomplete
+        pendingProjectInvites={pendingProjectInvites}
         allProjects={allProjects}
         plugin={newPlugin}
         setPlugin={setNewPlugin}

--- a/src/components/plugins/ProductsRadioForm.tsx
+++ b/src/components/plugins/ProductsRadioForm.tsx
@@ -2,7 +2,7 @@ import { ReactElement, ChangeEvent, Dispatch, SetStateAction } from "react";
 import { RadioGroup, FormControl } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { FormLabelControl } from "./FormLabelControl";
-import { IPlugin, Product } from "@/interfaces";
+import { IPluginOut, Product } from "@/interfaces";
 
 const useStyles = makeStyles({
   marginTop: { marginTop: "15px" },
@@ -11,8 +11,8 @@ const useStyles = makeStyles({
 });
 
 interface Props {
-  newPlugin: IPlugin;
-  setNewPlugin: Dispatch<SetStateAction<IPlugin>>;
+  newPlugin: IPluginOut;
+  setNewPlugin: Dispatch<SetStateAction<IPluginOut>>;
 }
 
 export const ProductsRadioForm = ({
@@ -25,7 +25,7 @@ export const ProductsRadioForm = ({
     <FormControl
       className={classes.marginTop}
       onChange={(e: ChangeEvent<HTMLInputElement>) => {
-        setNewPlugin((p) => ({ ...p, products: e.target.value } as IPlugin));
+        setNewPlugin((p) => ({ ...p, products: e.target.value } as IPluginOut));
       }}
     >
       <p className={classes.textFontSize}>Add plugin to:</p>

--- a/src/components/plugins/ProjectsAutocomplete.tsx
+++ b/src/components/plugins/ProjectsAutocomplete.tsx
@@ -10,8 +10,8 @@ import {
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import SVG from "react-inlinesvg";
-import { icons, lightGrey } from "@gliff-ai/style";
-import { IPlugin, Project } from "@/interfaces";
+import { icons, lightGrey, theme, middleGrey } from "@gliff-ai/style";
+import { IPluginOut, Project } from "@/interfaces";
 
 const useStyles = makeStyles({
   marginTop: { marginTop: "15px" },
@@ -25,6 +25,13 @@ const useStyles = makeStyles({
   chipLabel: {
     margin: "5px 5px 0 0",
     borderColor: "black",
+    color: "black",
+    borderRadius: "9px",
+  },
+  chipLabelPending: {
+    margin: "5px 5px 0 0",
+    borderColor: middleGrey,
+    color: middleGrey,
     borderRadius: "9px",
   },
   closeIcon: { width: "15px", height: "auto" },
@@ -32,14 +39,16 @@ const useStyles = makeStyles({
 
 interface Props {
   allProjects: Project[];
-  plugin: IPlugin;
-  setPlugin: Dispatch<SetStateAction<IPlugin>>;
+  plugin: IPluginOut;
+  setPlugin: Dispatch<SetStateAction<IPluginOut>>;
+  pendingProjectInvites?: string[];
 }
 
 export const ProjectsAutocomplete = ({
   allProjects,
   plugin,
   setPlugin,
+  pendingProjectInvites,
 }: Props): ReactElement => {
   const classes = useStyles();
 
@@ -73,7 +82,9 @@ export const ProjectsAutocomplete = ({
         )}
         onChange={updatePluginProjects}
         renderTags={() => null}
-        options={allProjects}
+        options={allProjects.filter(
+          ({ uid }) => !pendingProjectInvites.includes(uid)
+        )}
         getOptionLabel={(option: Project) => option.name}
         renderOption={(props, option) => (
           <li {...props} className={classes.option}>
@@ -105,12 +116,16 @@ export const ProjectsAutocomplete = ({
       />
       <List>
         {allProjects
-          .filter(({ uid }) => plugin.collection_uids.includes(uid))
+          .filter(
+            ({ uid }) =>
+              plugin.collection_uids.includes(uid) &&
+              !pendingProjectInvites.includes(uid)
+          )
           ?.map((project) => (
             <Chip
               variant="outlined"
-              key={project.name}
               className={classes.chipLabel}
+              key={project.name}
               label={project.name}
               avatar={
                 <Avatar
@@ -127,7 +142,25 @@ export const ProjectsAutocomplete = ({
               }
             />
           ))}
+        {allProjects
+          .filter(
+            ({ uid }) =>
+              plugin.collection_uids.includes(uid) &&
+              pendingProjectInvites.includes(uid)
+          )
+          ?.map((project) => (
+            <Chip
+              variant="outlined"
+              className={classes.chipLabelPending}
+              key={project.name}
+              label={project.name}
+            />
+          ))}
       </List>
     </>
   );
+};
+
+ProjectsAutocomplete.defaultProps = {
+  pendingProjectInvites: [],
 };

--- a/src/components/plugins/ProjectsAutocomplete.tsx
+++ b/src/components/plugins/ProjectsAutocomplete.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import SVG from "react-inlinesvg";
-import { icons, lightGrey, theme, middleGrey } from "@gliff-ai/style";
+import { icons, lightGrey, middleGrey } from "@gliff-ai/style";
 import { IPluginOut, Project } from "@/interfaces";
 
 const useStyles = makeStyles({

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -70,12 +70,19 @@ export enum PluginType {
   "AI" = "AI",
 }
 
-export interface IPlugin {
+interface IPlugin {
   username?: string;
   type: PluginType;
   name: string;
   url: string;
   products: Product;
   enabled: boolean;
+}
+
+export interface IPluginIn extends IPlugin {
+  collection_uids: { uid: string; is_invite_pending: "True" | "False" }[];
+}
+
+export interface IPluginOut extends IPlugin {
   collection_uids: string[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -80,7 +80,7 @@ interface IPlugin {
 }
 
 export interface IPluginIn extends IPlugin {
-  collection_uids: { uid: string; is_invite_pending: "True" | "False" }[];
+  collection_uids: { uid: string; is_invite_pending: boolean }[];
 }
 
 export interface IPluginOut extends IPlugin {

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -126,7 +126,7 @@ export const PluginsView = ({ services }: Props): ReactElement => {
         newPlugins.map((p) => {
           if (p.type !== PluginType.Javascript) {
             newPendingInvites[`${p.url}`] = p.collection_uids
-              .filter(({ is_invite_pending }) => is_invite_pending === "True")
+              .filter(({ is_invite_pending }) => is_invite_pending)
               .map(({ uid }) => uid);
           }
           return {


### PR DESCRIPTION
## Description
Improve the assignment of plugins to projects, by excluding from the dropdown menu those projects for which a pending invitation already exists and by listing the projects in grey, to indicate the plugin cannot be unassigned from these projects, until the invites are accepted. 

We have used this same solution in the assignment of users to projects.

### Details:
- change the plugin data returned by `getPlugins`, where the field`collection_uids`, before a list of uids, is now a list of dictionaries, with fields `uid` and `is_invite_pending`.
- split the plugin interface into input and output data.

relates to gliff-ai/dominate/issues/657

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
